### PR TITLE
node count and index

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -140,7 +140,7 @@ jobs:
           path: integrations/check-run-reporter-buildkite-plugin/bin
       # artifacts strip file permissions
       - run: chmod +x integrations/check-run-reporter-buildkite-plugin/bin/*
-      - run: ./integrations/check-run-reporter-buildkite-plugin/tests/bats/bin/bats ./integrations/check-run-reporter-buildkite-plugin/tests/post-command.bats
+      - run: ./integrations/check-run-reporter-buildkite-plugin/tests/bats/bin/bats ./integrations/check-run-reporter-buildkite-plugin/tests/*.bats
 
   release:
     needs:

--- a/README.md
+++ b/README.md
@@ -71,12 +71,28 @@ has seen before will be evenly distributed while new test will be spread
 round-robin.
 
 ```sh
+JEST_JUNIT_OUTPUT_DIR='reports/junit' \
+JEST_JUNIT_ANCESTOR_SEPARATOR=' › ' \
+JEST_JUNIT_CLASSNAME='{classname}' \
+JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT=true \
+JEST_JUNIT_OUTPUT_NAME='jest.xml' \
+JEST_JUNIT_SUITE_NAME='Some Label' \
+JEST_JUNIT_TITLE='{title}' \
+
 npx jest $(crr split \
   --label='Unit Tests' \
   --nodeCount=3 \
   --nodeIndex=1 \
   --tests='src/**/*.spec.ts' \
   --token=$CHECK_RUN_REPORTER_TOKEN)
+
+crr submit \
+  --label='Some Label' \
+  --nodeCount=3 \
+  --nodeIndex=1 \
+  --report='reports/junit/**/*.xml' \
+  --token='<your token>' \
+  --sha="$(git rev-parse HEAD)"
 ```
 
 ## Maintainers

--- a/integrations/action/README.md
+++ b/integrations/action/README.md
@@ -44,7 +44,7 @@ jobs:
         steps:
             - uses: actions/checkout@master
             - uses: actions/setup-node@v1
-            with:
+              with:
                 node-version: '12.x'
             - run: npm ci
             - run: npm test
@@ -60,9 +60,9 @@ You can declare the action multiple times if you'd like to do separate
 submissions with different labels (for example, you want separate style report
 and test report submissions).
 
-Note the `if: ${{ always() }}`. By default, GitHub actions exit as soon as step
-fails. You'll need to tell GitHub to run even in event of failure to ensure your
-reports are submitted.
+Note the `if: ${{ always() }}`. By default, GitHub actions exit as soon as a
+step fails. You'll need to tell GitHub to run even in event of failure to ensure
+your reports are submitted.
 
 > See [action.yml](action.yml) for full configuration options.
 

--- a/integrations/action/action.yml
+++ b/integrations/action/action.yml
@@ -1,6 +1,6 @@
 name: 'Check Run Reporter'
 description: |
-  A GitHub action for uploading structured test reports to Check Run Reporter
+  A GitHub action for uploading structured test reports to check-run-reporter.com for reporting, stability analysic, and optimization.
 branding:
   icon: 'check'
   color: 'orange'
@@ -13,9 +13,11 @@ inputs:
       Label that should appear in the GitHub check. Defaults to the step's name.
     required: false
   nodeCount:
+    default: '1'
     description: The total number of nodes you intend to spin up
     required: false
   nodeIndex:
+    default: '0'
     description: This node's index.
     required: false
   report:

--- a/integrations/check-run-reporter-buildkite-plugin/tests/post-command.bats
+++ b/integrations/check-run-reporter-buildkite-plugin/tests/post-command.bats
@@ -59,7 +59,6 @@ setup() {
     run "post-command"
 
     assert_failure
-    assert_output --partial 'code 401'
-    # The API isn't currently returning the following message.
-    # assert_output --partial 'Could not find repo token in Authorization header'
+    assert_output --partial 'code 403'
+    assert_output --partial 'Specified token does not identify a repository'
 }

--- a/integrations/check-run-reporter-buildkite-plugin/tests/pre-command-wrapper
+++ b/integrations/check-run-reporter-buildkite-plugin/tests/pre-command-wrapper
@@ -5,8 +5,11 @@
 
 set -euo pipefail
 
-source pre-command
-env | awk '
-  /CHECK_RUN_REPORTER_TESTS_FOR_THIS_AGENT/ { found = 1 }
-  found { print $0}
-'
+# Reminder, this has to be sourced so that it can change the environment of the
+# current process so that the next line can work
+source pre-command &>/dev/null
+
+# I don't really know what this command does, but I couldn't quite get awk to do
+# what I wanted and after a few rounds with ChatGPT that did nothing, this
+# appears to work.
+env | sed -n '/^CHECK_RUN_REPORTER_TESTS_FOR_THIS_AGENT=/,/^.*$/p'

--- a/integrations/check-run-reporter-buildkite-plugin/tests/pre-command.bats
+++ b/integrations/check-run-reporter-buildkite-plugin/tests/pre-command.bats
@@ -29,8 +29,8 @@ setup() {
 
     assert_success
 
-    assert_line --index 0 CHECK_RUN_REPORTER_TESTS_FOR_THIS_AGENT=logger.spec.ts
-    assert_line --index 1 'user.spec.ts'
+    assert_output 'CHECK_RUN_REPORTER_TESTS_FOR_THIS_AGENT=logger.spec.ts
+user.spec.ts'
 }
 
 @test "Without tests input" {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,6 +101,14 @@ export function cli(argv: string[]) {
             description: 'Label that should appear in the GitHub check run.',
             type: 'string',
           },
+          nodeCount: {
+            default: 1,
+            type: 'number',
+          },
+          nodeIndex: {
+            default: 0,
+            type: 'number',
+          },
           report: {
             demandOption: true,
             description:

--- a/src/commands/submit.spec.ts
+++ b/src/commands/submit.spec.ts
@@ -17,7 +17,17 @@ describe('submit()', () => {
 
   it('submits reports to check run reporter using multistep upload', async () => {
     nock('https://api.check-run-reporter.com')
-      .post('/api/v1/submissions/upload')
+      .post(
+        '/api/v1/submissions/upload',
+        JSON.stringify({
+          filenames: ['reports/junit/jest.xml'],
+          label: 'foo',
+          nodeCount: 1,
+          nodeIndex: 0,
+          root: '/',
+          sha: '40923a72ddf9eefef938355fa96246607c706f6c',
+        })
+      )
       .reply(201, {
         keys: [
           'ianwremmel/check-run-reporter/c6fb3d5423762aa2b3a8f63717ef6b320e5a1b5a/SOMEUUID-reports/junit/jest.xml',
@@ -29,15 +39,34 @@ describe('submit()', () => {
         },
       });
 
+    // Mock with and without a port due to potential environment differences
+    // that shouldn't actually matter.
     nock('https://example.com').put('/1').reply(200);
+    nock('https://example.com:443').put('/1').reply(200);
 
     nock('https://api.check-run-reporter.com')
-      .patch('/api/v1/submissions/upload')
+      .patch(
+        '/api/v1/submissions/upload',
+        JSON.stringify({
+          keys: [
+            'ianwremmel/check-run-reporter/c6fb3d5423762aa2b3a8f63717ef6b320e5a1b5a/SOMEUUID-reports/junit/jest.xml',
+          ],
+          label: 'foo',
+          nodeCount: 1,
+          nodeIndex: 0,
+          root: '/',
+          sha: '40923a72ddf9eefef938355fa96246607c706f6c',
+          signature:
+            '19c3cb9748107142317f4eb212b61d2be19a8c4b2aff9dc6117a7936b28313e5',
+        })
+      )
       .reply(202);
 
     await submit(
       {
         label: 'foo',
+        nodeCount: 1,
+        nodeIndex: 0,
         report: ['reports/junit/**/*.xml'],
         root: '/',
         sha: '40923a72ddf9eefef938355fa96246607c706f6c',

--- a/src/commands/submit.spec.ts
+++ b/src/commands/submit.spec.ts
@@ -46,25 +46,4 @@ describe('submit()', () => {
       makeTestContext()
     );
   });
-
-  it('submits reports to check run reporter, falling back to single step upload', async () => {
-    nock('https://api.check-run-reporter.com')
-      .post('/api/v1/submissions/upload')
-      .reply(404);
-
-    nock('https://api.check-run-reporter.com')
-      .post('/api/v1/submissions')
-      .reply(201);
-
-    await submit(
-      {
-        label: 'foo',
-        report: ['reports/junit/**/*.xml'],
-        root: '/',
-        sha: '40923a72ddf9eefef938355fa96246607c706f6c',
-        token: 'FAKE TOKEN',
-      },
-      makeTestContext()
-    );
-  });
 });

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -8,6 +8,8 @@ import {getRequestId} from '../lib/axios';
 
 interface SubmitArgs {
   readonly label: Optional<string>;
+  readonly nodeCount: number;
+  readonly nodeIndex: number;
   readonly report: readonly string[];
   readonly root: string;
   readonly sha: string;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -3,7 +3,7 @@ import ci from 'ci-info';
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 /**
- * Some CI services incldue utility syntax for doing novel things with log
+ * Some CI services include utility syntax for doing novel things with log
  * output. The Logger interfaces lets us do "the right thing" for those
  * services.
  */

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -7,6 +7,8 @@ import {Context, Optional} from './types';
 
 interface UploadArgs {
   readonly label: Optional<string>;
+  readonly nodeCount: number;
+  readonly nodeIndex: number;
   readonly report: readonly string[];
   readonly root: string;
   readonly sha: string;
@@ -53,11 +55,11 @@ export async function getSignedUploadUrls(
   filenames: readonly string[],
   {client}: Context
 ): Promise<{keys: string[]; signature: string; urls: Record<string, string>}> {
-  const {label, root, sha, token} = args;
+  const {label, nodeCount, nodeIndex, root, sha, token} = args;
 
   const response = await client.post(
     PATH_MULTI_STEP_UPLOAD,
-    {filenames, label, root, sha},
+    {filenames, label, nodeCount, nodeIndex, root, sha},
     {
       auth: {password: token, username: 'token'},
       maxContentLength: Infinity,
@@ -94,13 +96,15 @@ export async function finishMultistepUpload(
   signature: string,
   {client}: Context
 ) {
-  const {label, root, sha, token} = args;
+  const {label, nodeCount, nodeIndex, root, sha, token} = args;
 
   const response = await client.patch(
     PATH_MULTI_STEP_UPLOAD,
     {
       keys,
       label,
+      nodeCount,
+      nodeIndex,
       root,
       sha,
       signature,


### PR DESCRIPTION
- ci: run all bats tests
- test: fix all buildkite tests
- refactor: remove single-step-upload now that the backend has support multistep for some time
- fixup! refactor: remove single-step-upload now that the backend has support multistep for some time
- feat: add nodeCount and nodeIndex to all requests
